### PR TITLE
Plot prevalence alongside PRAUC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # back_to_the_dashboard
 
 A minimal Flask dashboard that parses training logs for trading models and
-displays a PRAUC chart.
+displays PRAUC and prevalence charts.
 
 ## Usage
 1. Install dependencies
@@ -18,5 +18,5 @@ displays a PRAUC chart.
 
 Example log line expected by the parser:
 ```
-[val 20220105] ep 01 tr:loss=0.6596 | va:APμ=0.6367 AP̄=0.3606 F1̄=0.7351 sel=prauc:0.6367 (time=0.9s)
+[val 20220105] ep 01 tr:loss=0.6596 | va:APμ=0.6367 AP̄=0.3606 F1̄=0.7351 prev=0.02 sel=prauc:0.6367 (time=0.9s)
 ```

--- a/dashboard.py
+++ b/dashboard.py
@@ -9,7 +9,7 @@ LOG_FILE = Path("train.log")
 app = Flask(__name__)
 
 LOG_RE = re.compile(
-    r"\[val (\d+)\] ep (\d+) tr:loss=(\d+\.\d+) \| va:APμ=(\d+\.\d+) AP̄=(\d+\.\d+) F1̄=(\d+\.\d+) sel=prauc:(\d+\.\d+)"
+    r"\[val (\d+)\] ep (\d+) tr:loss=(\d+\.\d+) \| va:APμ=(\d+\.\d+) AP̄=(\d+\.\d+) F1̄=(\d+\.\d+)(?: prev=(\d+\.\d+))? sel=prauc:(\d+\.\d+)"
 )
 
 
@@ -22,7 +22,7 @@ def parse_logs():
         for line in f:
             m = LOG_RE.search(line)
             if m:
-                date, epoch, loss, ap_mu, ap_bar, f1_bar, prauc = m.groups()
+                date, epoch, loss, ap_mu, ap_bar, f1_bar, prevalence, prauc = m.groups()
                 entries.append(
                     {
                         "date": date,
@@ -31,6 +31,7 @@ def parse_logs():
                         "ap_mu": float(ap_mu),
                         "ap_bar": float(ap_bar),
                         "f1_bar": float(f1_bar),
+                        "prevalence": float(prevalence) if prevalence is not None else None,
                         "prauc": float(prauc),
                     }
                 )

--- a/sample.log
+++ b/sample.log
@@ -9,13 +9,13 @@
   --lr 1e-3 --grad_accum 2 --weight_decay 1e-4
 [cuda] using device 0: NVIDIA GeForce RTX 5090
 [amp] enabled=True dtype=torch.float32 device=cuda
-[val 20220105] ep 01 tr:loss=0.6596 | va:APμ=0.6367 AP̄=0.3606 F1̄=0.7351 sel=prauc:0.6367 (time=0.9s)
+[val 20220105] ep 01 tr:loss=0.6596 | va:APμ=0.6367 AP̄=0.3606 F1̄=0.7351 prev=0.02 sel=prauc:0.6367 (time=0.9s)
 [best-epoch] New best prauc=0.6367 -> /home/jason/ml/datasets/models/prepped_setup12_60_setup/model_val20220105.pt
-[val 20220105] ep 02 tr:loss=0.6174 | va:APμ=0.6347 AP̄=0.3593 F1̄=0.7351 sel=prauc:0.6347 (time=0.4s)
-[val 20220105] ep 03 tr:loss=0.5790 | va:APμ=0.6388 AP̄=0.3625 F1̄=0.7352 sel=prauc:0.6388 (time=0.3s)
+[val 20220105] ep 02 tr:loss=0.6174 | va:APμ=0.6347 AP̄=0.3593 F1̄=0.7351 prev=0.02 sel=prauc:0.6347 (time=0.4s)
+[val 20220105] ep 03 tr:loss=0.5790 | va:APμ=0.6388 AP̄=0.3625 F1̄=0.7352 prev=0.02 sel=prauc:0.6388 (time=0.3s)
 [best-epoch] New best prauc=0.6388 -> /home/jason/ml/datasets/models/prepped_setup12_60_setup/model_val20220105.pt
-[val 20220105] ep 04 tr:loss=0.5655 | va:APμ=0.6508 AP̄=0.3686 F1̄=0.7351 sel=prauc:0.6508 (time=0.3s)
+[val 20220105] ep 04 tr:loss=0.5655 | va:APμ=0.6508 AP̄=0.3686 F1̄=0.7351 prev=0.02 sel=prauc:0.6508 (time=0.3s)
 [best-epoch] New best prauc=0.6508 -> /home/jason/ml/datasets/models/prepped_setup12_60_setup/model_val20220105.pt
-[val 20220105] ep 05 tr:loss=0.5470 | va:APμ=0.6539 AP̄=0.3705 F1̄=0.7352 sel=prauc:0.6539 (time=0.3s)
+[val 20220105] ep 05 tr:loss=0.5470 | va:APμ=0.6539 AP̄=0.3705 F1̄=0.7352 prev=0.02 sel=prauc:0.6539 (time=0.3s)
 [best-epoch] New best prauc=0.6539 -> /home/jason/ml/datasets/models/prepped_setup12_60_setup/model_val20220105.pt
-[val 20220106] ep 01 tr:loss=0.5890 | va:APμ=0.2683 AP̄=0.2560 F1̄=0.3894 sel=prauc:0.2683 (time=0.8s)
+[val 20220106] ep 01 tr:loss=0.5890 | va:APμ=0.2683 AP̄=0.2560 F1̄=0.3894 prev=0.30 sel=prauc:0.2683 (time=0.8s)

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
-  <h1>Training PRAUC</h1>
+  <h1>Training PRAUC and Prevalence</h1>
   <canvas id="praucChart"></canvas>
   <script>
     let chart;
@@ -18,16 +18,24 @@
       const data = await fetchData();
       const labels = data.map(d => `${d.date} ep${d.epoch}`);
       const prauc = data.map(d => d.prauc);
+      const prevalence = data.map(d => d.prevalence);
       if (!chart) {
         const ctx = document.getElementById('praucChart').getContext('2d');
         chart = new Chart(ctx, {
           type: 'line',
-          data: { labels, datasets: [{ label: 'PRAUC', data: prauc, borderColor: 'blue' }] },
+          data: {
+            labels,
+            datasets: [
+              { label: 'PRAUC', data: prauc, borderColor: 'blue' },
+              { label: 'Prevalence', data: prevalence, borderColor: 'orange' }
+            ]
+          },
           options: { scales: { y: { beginAtZero: true, max: 1 } } }
         });
       } else {
         chart.data.labels = labels;
         chart.data.datasets[0].data = prauc;
+        chart.data.datasets[1].data = prevalence;
         chart.update();
       }
     }


### PR DESCRIPTION
## Summary
- parse optional prevalence values from training logs
- chart prevalence alongside PRAUC for context
- document prevalence usage and update sample log

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8d3dc554c83278d64e9c01ca025ee