### PR TITLE
Add PRAUC and prevalence dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,8 @@
+from flask import Flask
+from metrics_backend import metrics_bp
+
+app = Flask(__name__, template_folder="templates", static_folder="static")
+app.register_blueprint(metrics_bp)
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/metrics_backend.py
+++ b/metrics_backend.py
@@ -1,0 +1,138 @@
+import json
+import os
+import statistics
+from pathlib import Path
+from typing import Iterable, List, Dict, Any, Optional
+
+from flask import Blueprint, jsonify, render_template, request
+
+DEFAULT_METRICS_PATH = "/home/jason/ml/datasets/models/prepped_setup12_60_setup/metrics.jsonl"
+DEFAULT_TITLE = "Walk-Forward PRAUC"
+
+metrics_bp = Blueprint("metrics_bp", __name__)
+
+
+def get_metrics_path() -> Path:
+    return Path(os.environ.get("METRICS_PATH", DEFAULT_METRICS_PATH))
+
+
+def tail_lines(path: Path, limit: int) -> Iterable[str]:
+    """Yield lines from the end of file efficiently."""
+    if limit <= 0:
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                yield line
+        return
+    with path.open("rb") as f:
+        f.seek(0, os.SEEK_END)
+        end = f.tell()
+        size = 1024
+        data = bytearray()
+        while end > 0 and data.count(b"\n") <= limit:
+            read_size = min(size, end)
+            f.seek(end - read_size)
+            chunk = f.read(read_size)
+            data[:0] = chunk
+            end -= read_size
+            if end == 0:
+                break
+        lines = data.splitlines()
+        if len(lines) > limit:
+            lines = lines[-limit:]
+        for line in lines:
+            yield line.decode("utf-8", errors="ignore")
+
+
+def parse_metrics(limit: int, since_day: Optional[str]) -> List[Dict[str, Any]]:
+    path = get_metrics_path()
+    if not path.exists():
+        return []
+    rows: List[Dict[str, Any]] = []
+    for line in tail_lines(path, limit):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        day = obj.get("day")
+        if isinstance(day, int):
+            day = f"{day:08d}"
+        else:
+            day = str(day)
+        if since_day and day < since_day:
+            continue
+        row = {
+            "day": day,
+            "epoch": int(obj.get("epoch", 0)),
+            "train_loss": float(obj.get("train_loss", 0.0)),
+            "time_s": float(obj.get("time_s", 0.0)),
+            "ap_micro": float(obj.get("ap_micro", 0.0)),
+            "ap_macro": float(obj.get("ap_macro", 0.0)),
+            "prev_micro": float(obj.get("prev_micro", 0.0)),
+            "prev_macro": float(obj.get("prev_macro", 0.0)),
+            "pos_total": int(obj.get("pos_total", 0)),
+            "neg_total": int(obj.get("neg_total", 0)),
+        }
+        rows.append(row)
+    rows.sort(key=lambda r: (r["day"], r["epoch"]))
+    return rows
+
+
+def aggregate_rows(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    best: Dict[str, Dict[str, Any]] = {}
+    for r in rows:
+        day = r["day"]
+        if day not in best:
+            best[day] = r
+        else:
+            b = best[day]
+            if r["ap_micro"] > b["ap_micro"] or (
+                r["ap_micro"] == b["ap_micro"] and r["epoch"] < b["epoch"]
+            ):
+                best[day] = r
+    return [best[d] for d in sorted(best.keys())]
+
+
+def compute_summary(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    if not rows:
+        return {
+            "count_rows": 0,
+            "days": 0,
+            "ap_micro_mean": 0,
+            "ap_micro_median": 0,
+            "prev_micro_mean": 0,
+        }
+    ap_values = [r["ap_micro"] for r in rows]
+    prev_values = [r["prev_micro"] for r in rows]
+    return {
+        "count_rows": len(rows),
+        "days": len({r["day"] for r in rows}),
+        "ap_micro_mean": statistics.mean(ap_values),
+        "ap_micro_median": statistics.median(ap_values),
+        "prev_micro_mean": statistics.mean(prev_values) if prev_values else 0,
+    }
+
+
+@metrics_bp.route("/api/metrics")
+def api_metrics():
+    limit = int(request.args.get("limit", 0))
+    since_day = request.args.get("since_day")
+    if since_day is not None:
+        since_day = str(since_day)
+        if since_day.isdigit():
+            since_day = f"{int(since_day):08d}"
+    aggregate = request.args.get("aggregate", "true").lower() != "false"
+
+    rows = parse_metrics(limit, since_day)
+    summary = compute_summary(rows)
+    best = aggregate_rows(rows) if aggregate else []
+
+    return jsonify({"summary": summary, "best_per_day": best, "rows": rows})
+
+
+@metrics_bp.route("/dashboard/metrics")
+def dashboard():
+    title = os.environ.get("DASHBOARD_TITLE", DEFAULT_TITLE)
+    return render_template("metrics.html", title=title)

--- a/scripts/emit_dummy_metrics.py
+++ b/scripts/emit_dummy_metrics.py
@@ -1,0 +1,36 @@
+import json
+import os
+import random
+from datetime import datetime
+from pathlib import Path
+
+DEFAULT_METRICS_PATH = "/home/jason/ml/datasets/models/prepped_setup12_60_setup/metrics.jsonl"
+
+
+def main():
+    path = Path(os.environ.get("METRICS_PATH", DEFAULT_METRICS_PATH))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    day = datetime.now().strftime("%Y%m%d")
+    records = []
+    for epoch in range(1, 4):
+        rec = {
+            "day": day,
+            "epoch": epoch,
+            "train_loss": round(random.uniform(0.5, 1.0), 4),
+            "time_s": round(random.uniform(0.5, 3.0), 2),
+            "ap_micro": round(random.uniform(0, 1), 4),
+            "ap_macro": round(random.uniform(0, 1), 4),
+            "prev_micro": round(random.uniform(0, 0.2), 4),
+            "prev_macro": round(random.uniform(0, 0.2), 4),
+            "pos_total": random.randint(0, 2000),
+            "neg_total": random.randint(1000, 5000),
+        }
+        records.append(rec)
+    with path.open("a", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(rec) + "\n")
+    print(f"Wrote {len(records)} rows to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/static/metrics.css
+++ b/static/metrics.css
@@ -1,0 +1,7 @@
+.kpi {
+  font-size: 1.1rem;
+}
+.kpi span {
+  font-weight: bold;
+  font-size: 1.25rem;
+}

--- a/static/metrics.js
+++ b/static/metrics.js
@@ -1,0 +1,139 @@
+let chart;
+let timer;
+
+function buildChart(data) {
+  const ctx = document.getElementById('metricsChart').getContext('2d');
+  const labels = data.map(r => r.day);
+  const apDataset = {
+    label: 'APμ',
+    data: data.map(r => ({x: r.day, y: r.ap_micro, pos_total: r.pos_total})),
+    parsing: false,
+    tension: 0,
+    borderColor: 'rgb(54, 162, 235)',
+    backgroundColor: 'rgb(54, 162, 235)',
+    pointRadius: 4,
+    pointBackgroundColor: ctx => ctx.raw.pos_total === 0 ? '#ffffff' : 'rgb(54,162,235)',
+    pointBorderColor: 'rgb(54,162,235)',
+  };
+  const prevDataset = {
+    label: 'Prevμ',
+    data: data.map(r => ({x: r.day, y: r.prev_micro})),
+    parsing: false,
+    tension: 0,
+    borderColor: 'rgb(255, 159, 64)',
+    backgroundColor: 'rgb(255, 159, 64)',
+    pointRadius: 4,
+  };
+  if (chart) {
+    chart.data.labels = labels;
+    chart.data.datasets[0] = apDataset;
+    chart.data.datasets[1] = prevDataset;
+    chart.update();
+  } else {
+    chart = new Chart(ctx, {
+      type: 'line',
+      data: {labels, datasets: [apDataset, prevDataset]},
+      options: {
+        responsive: true,
+        scales: { y: {min: 0, max: 1} },
+        plugins: {
+          tooltip: {
+            callbacks: {
+              label: function(context) {
+                const val = context.parsed.y.toFixed(4);
+                if (context.raw.pos_total === 0) {
+                  return context.dataset.label + ': ' + val + ' (zero positives)';
+                }
+                return context.dataset.label + ': ' + val;
+              }
+            }
+          }
+        }
+      }
+    });
+  }
+}
+
+function populateTable(data) {
+  const tbody = document.querySelector('#metricsTable tbody');
+  tbody.innerHTML = '';
+  for (const r of data) {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${r.day}</td>
+      <td>${r.epoch}</td>
+      <td>${r.ap_micro.toFixed(4)}</td>
+      <td>${r.ap_macro.toFixed(4)}</td>
+      <td>${r.prev_micro.toFixed(4)}</td>
+      <td>${r.pos_total}</td>
+      <td>${r.neg_total}</td>
+      <td>${r.train_loss.toFixed(4)}</td>
+      <td>${r.time_s.toFixed(2)}</td>`;
+    tbody.appendChild(tr);
+  }
+}
+
+function updateKpis(summary) {
+  document.getElementById('kpiMean').textContent = summary.ap_micro_mean.toFixed(4);
+  document.getElementById('kpiMedian').textContent = summary.ap_micro_median.toFixed(4);
+  document.getElementById('kpiPrev').textContent = summary.prev_micro_mean.toFixed(4);
+  document.getElementById('kpiDays').textContent = summary.days;
+}
+
+function showError(msg) {
+  const el = document.getElementById('error');
+  el.textContent = msg;
+  el.classList.remove('d-none');
+}
+
+function clearError() {
+  const el = document.getElementById('error');
+  el.classList.add('d-none');
+}
+
+function fetchMetrics() {
+  clearError();
+  const startDay = document.getElementById('startDay').value.trim();
+  const endDay = document.getElementById('endDay').value.trim();
+  const limit = document.getElementById('limit').value.trim();
+  let url = '/api/metrics?aggregate=true';
+  if (limit) url += `&limit=${limit}`;
+  if (startDay) url += `&since_day=${startDay}`;
+  url += `&t=${Date.now()}`;
+  fetch(url, {cache: 'no-store'})
+    .then(resp => resp.json())
+    .then(data => {
+      let rows = data.best_per_day;
+      if (endDay) {
+        rows = rows.filter(r => r.day <= endDay);
+      }
+      buildChart(rows);
+      populateTable(rows);
+      updateKpis(data.summary);
+    })
+    .catch(err => {
+      showError('Failed to load metrics');
+      console.error(err);
+    });
+}
+
+function setupRefresh() {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+  const auto = document.getElementById('autoRefresh').checked;
+  const interval = parseInt(document.getElementById('refreshInterval').value || '5', 10) * 1000;
+  if (auto) {
+    timer = setInterval(fetchMetrics, interval);
+  }
+}
+
+document.getElementById('refreshBtn').addEventListener('click', fetchMetrics);
+
+['autoRefresh', 'refreshInterval'].forEach(id => {
+  document.getElementById(id).addEventListener('change', setupRefresh);
+});
+
+fetchMetrics();
+setupRefresh();

--- a/templates/metrics.html
+++ b/templates/metrics.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ title }}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <link rel="stylesheet" href="{{ url_for('static', filename='metrics.css') }}">
+  </head>
+  <body class="bg-light">
+    <div class="container py-4">
+      <h1 class="mb-4">{{ title }}</h1>
+      <div id="error" class="alert alert-danger d-none" role="alert"></div>
+
+      <form id="controls" class="row g-2 mb-4">
+        <div class="col-md-2">
+          <label class="form-label">Start day</label>
+          <input type="text" class="form-control" id="startDay" placeholder="YYYYMMDD">
+        </div>
+        <div class="col-md-2">
+          <label class="form-label">End day</label>
+          <input type="text" class="form-control" id="endDay" placeholder="YYYYMMDD">
+        </div>
+        <div class="col-md-2">
+          <label class="form-label">Last N rows</label>
+          <input type="number" class="form-control" id="limit" min="0" placeholder="0">
+        </div>
+        <div class="col-md-2">
+          <label class="form-label">Refresh (s)</label>
+          <input type="number" class="form-control" id="refreshInterval" value="5" min="1">
+        </div>
+        <div class="col-md-2 d-flex align-items-end">
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="autoRefresh" checked>
+            <label class="form-check-label" for="autoRefresh">Auto-refresh</label>
+          </div>
+        </div>
+        <div class="col-md-2 d-flex align-items-end">
+          <button type="button" id="refreshBtn" class="btn btn-primary w-100">Refresh</button>
+        </div>
+      </form>
+
+      <div class="row mb-4 text-center" id="kpis">
+        <div class="col"><div class="kpi"><span id="kpiMean">0</span><br>mean APμ</div></div>
+        <div class="col"><div class="kpi"><span id="kpiMedian">0</span><br>median APμ</div></div>
+        <div class="col"><div class="kpi"><span id="kpiPrev">0</span><br>mean Prevμ</div></div>
+        <div class="col"><div class="kpi"><span id="kpiDays">0</span><br>days</div></div>
+      </div>
+
+      <canvas id="metricsChart" height="120"></canvas>
+
+      <h2 class="mt-4">Best per day</h2>
+      <div class="table-responsive">
+        <table class="table table-sm table-striped" id="metricsTable">
+          <thead>
+            <tr>
+              <th>Day</th>
+              <th>Epoch</th>
+              <th>APμ</th>
+              <th>AP̄</th>
+              <th>Prevμ</th>
+              <th>Pos</th>
+              <th>Neg</th>
+              <th>TrainLoss</th>
+              <th>Time(s)</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
+    <script src="{{ url_for('static', filename='metrics.js') }}"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Serve PRAUC and prevalence metrics via `/api/metrics`
- Add auto-refreshing dashboard with Chart.js and controls
- Provide script to emit dummy metrics for testing

## Testing
- `python -m py_compile app.py metrics_backend.py scripts/emit_dummy_metrics.py`
- `python scripts/emit_dummy_metrics.py`
- `python - <<'PY'
from app import app
client = app.test_client()
resp = client.get('/api/metrics')
print(resp.status_code)
print(resp.get_json())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a8df9aeba08327b0d1cc1f0b4cbbdb