### PR TITLE
Make metrics chart refresh animation more subtle

### DIFF
--- a/static/metrics.js
+++ b/static/metrics.js
@@ -48,8 +48,8 @@ function buildChart(data) {
   };
   if (chart) {
     chart.data.labels = labels;
-    chart.data.datasets[0] = apDataset;
-    chart.data.datasets[1] = prevDataset;
+    chart.data.datasets[0].data = apDataset.data;
+    chart.data.datasets[1].data = prevDataset.data;
     chart.update();
   } else {
     chart = new Chart(ctx, {
@@ -57,6 +57,10 @@ function buildChart(data) {
       data: {labels, datasets: [apDataset, prevDataset]},
       options: {
         responsive: true,
+        animation: {
+          duration: 300,
+          easing: 'linear'
+        },
         scales: { y: {min: 0, max: 1} },
         plugins: {
           tooltip: {


### PR DESCRIPTION
## Summary
- update chart refresh to reuse datasets and avoid bounce animation
- set a light linear animation for smoother transitions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8ef1cd37c8327b0db04e60972b18c