### PR TITLE
Add pagination to best per day table

### DIFF
--- a/templates/metrics.html
+++ b/templates/metrics.html
@@ -69,6 +69,9 @@
           <tbody></tbody>
           </table>
         </div>
+      <nav>
+        <ul class="pagination pagination-sm" id="pagination"></ul>
+      </nav>
     </div>
     <script>
       const GLOSSARY_URL = "{{ url_for('static', filename='glossary.json') }}";


### PR DESCRIPTION
## Summary
- Add Bootstrap pagination controls to the "Best per day" section of the dashboard
- Implement client-side pagination logic to navigate through aggregated metrics

## Testing
- `python -m py_compile app.py metrics_backend.py`
- `node --check static/metrics.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8f06ac5b48327904d40f07e7fbe56