### PR TITLE
Handle metric eligibility in dashboard

### DIFF
--- a/templates/metrics.html
+++ b/templates/metrics.html
@@ -57,6 +57,7 @@
             <tr>
               <th>Day</th>
               <th>Epoch</th>
+              <th>Status</th>
               <th data-term="APμ">APμ</th>
               <th data-term="AP̄">AP̄</th>
               <th data-term="prevμ">Prevμ</th>


### PR DESCRIPTION
## Summary
- Parse `eligible` field and compute summary and best-per-day using only eligible rows
- Return all rows to the frontend and draw ineligible points as hollow markers
- Show eligibility badges in metrics table

## Testing
- `python -m py_compile metrics_backend.py`
- `node --check static/metrics.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8fdb7997c8327ab7c61348d152748