### PR TITLE
Fix plotting to show one point per day on metrics chart

### DIFF
--- a/static/metrics.js
+++ b/static/metrics.js
@@ -211,7 +211,10 @@ function fetchMetrics() {
   fetch(url, {cache: 'no-store'})
     .then(resp => resp.json())
     .then(data => {
-      let chartRows = data.rows;
+      // Use aggregated rows for both the chart and table so the x-axis
+      // shows one point per day instead of multiple points stacked on
+      // the same day, which previously produced vertical lines.
+      let chartRows = data.best_per_day;
       let tableRows = data.best_per_day;
       if (endDay) {
         chartRows = chartRows.filter(r => r.day <= endDay);


### PR DESCRIPTION
## Summary
- Plot aggregated best-per-day data on the metrics chart to avoid vertical lines when multiple rows share the same day

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a9069815b88327a91dfba03e901ed0