### PR TITLE
Add ticker showing current day's epoch progress

### DIFF
--- a/static/metrics.css
+++ b/static/metrics.css
@@ -5,3 +5,11 @@
   font-weight: bold;
   font-size: 1.25rem;
 }
+
+.ticker {
+  max-height: 400px;
+  overflow-y: auto;
+  border-left: 1px solid #dee2e6;
+  padding-left: 0.5rem;
+  font-size: 0.875rem;
+}

--- a/static/metrics.js
+++ b/static/metrics.js
@@ -188,6 +188,19 @@ function updateKpis(summary) {
   document.getElementById('kpiDays').textContent = summary.days;
 }
 
+function updateTicker(rows) {
+  const ticker = document.getElementById('ticker');
+  ticker.innerHTML = '';
+  if (!rows.length) return;
+  const latestDay = rows[rows.length - 1].day;
+  const dayRows = rows.filter(r => r.day === latestDay);
+  for (const r of dayRows) {
+    const li = document.createElement('li');
+    li.textContent = `ep${r.epoch}: APμ ${r.ap_micro.toFixed(4)}`;
+    ticker.appendChild(li);
+  }
+}
+
 function showError(msg) {
   const el = document.getElementById('error');
   el.textContent = msg;
@@ -225,6 +238,7 @@ function fetchMetrics() {
       currentPage = 1;
       renderTable();
       updateKpis(data.summary);
+      updateTicker(data.rows);
     })
     .catch(err => {
       showError('Failed to load metrics');

--- a/templates/metrics.html
+++ b/templates/metrics.html
@@ -51,28 +51,36 @@
       <canvas id="metricsChart" height="120"></canvas>
 
       <h2 class="mt-4">Best per day</h2>
-      <div class="table-responsive">
-        <table class="table table-sm table-striped" id="metricsTable">
-          <thead>
-            <tr>
-              <th>Day</th>
-              <th>Epoch</th>
-              <th>Status</th>
-              <th data-term="APμ">APμ</th>
-              <th data-term="AP̄">AP̄</th>
-              <th data-term="prevμ">Prevμ</th>
-              <th data-term="pos">Pos</th>
-              <th data-term="neg">Neg</th>
-              <th data-term="loss">TrainLoss</th>
-              <th>Time(s)</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-          </table>
+      <div class="row">
+        <div class="col-md-9">
+          <div class="table-responsive">
+            <table class="table table-sm table-striped" id="metricsTable">
+              <thead>
+                <tr>
+                  <th>Day</th>
+                  <th>Epoch</th>
+                  <th>Status</th>
+                  <th data-term="APμ">APμ</th>
+                  <th data-term="AP̄">AP̄</th>
+                  <th data-term="prevμ">Prevμ</th>
+                  <th data-term="pos">Pos</th>
+                  <th data-term="neg">Neg</th>
+                  <th data-term="loss">TrainLoss</th>
+                  <th>Time(s)</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+              </table>
+            </div>
+          <nav>
+            <ul class="pagination pagination-sm" id="pagination"></ul>
+          </nav>
         </div>
-      <nav>
-        <ul class="pagination pagination-sm" id="pagination"></ul>
-      </nav>
+        <div class="col-md-3">
+          <h5>Today's progress</h5>
+          <ul id="ticker" class="ticker list-unstyled"></ul>
+        </div>
+      </div>
     </div>
     <script>
       const GLOSSARY_URL = "{{ url_for('static', filename='glossary.json') }}";


### PR DESCRIPTION
## Summary
- Add side ticker showing today's epoch metrics
- Style ticker and integrate with metrics table layout
- Update JS to populate ticker with latest day rows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa3b4a7b00832786d79d1a349d198c