### PR TITLE
Add lift_abs metric plot to training dashboard

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -19,6 +19,7 @@
       const labels = data.map(d => `${d.date} ep${d.epoch}`);
       const prauc = data.map(d => d.prauc);
       const prevalence = data.map(d => d.prevalence);
+      const liftAbs = data.map(d => d.lift_abs);
       if (!chart) {
         const ctx = document.getElementById('praucChart').getContext('2d');
         chart = new Chart(ctx, {
@@ -26,16 +27,27 @@
           data: {
             labels,
             datasets: [
-              { label: 'PRAUC', data: prauc, borderColor: 'blue' },
-              { label: 'Prevalence', data: prevalence, borderColor: 'orange' }
+              { label: 'PRAUC', data: prauc, borderColor: 'blue', yAxisID: 'y' },
+              { label: 'Prevalence', data: prevalence, borderColor: 'orange', yAxisID: 'y' },
+              { label: 'Lift Abs', data: liftAbs, borderColor: 'green', yAxisID: 'y1' }
             ]
           },
-          options: { scales: { y: { beginAtZero: true, max: 1 } } }
+          options: {
+            scales: {
+              y: { beginAtZero: true, max: 1 },
+              y1: {
+                beginAtZero: true,
+                position: 'right',
+                grid: { drawOnChartArea: false }
+              }
+            }
+          }
         });
       } else {
         chart.data.labels = labels;
         chart.data.datasets[0].data = prauc;
         chart.data.datasets[1].data = prevalence;
+        chart.data.datasets[2].data = liftAbs;
         chart.update();
       }
     }


### PR DESCRIPTION
## Summary
- parse optional `lift_abs` from training logs and include it in API data
- chart `lift_abs` alongside PRAUC and prevalence using a secondary axis

## Testing
- `python -m py_compile dashboard.py`
- `python - <<'PY'
import dashboard
from pathlib import Path

dashboard.LOG_FILE = Path('sample.log')
print(dashboard.parse_logs()[:2])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68acea3cea208327998d5c46a110c535