### PR TITLE
Add script for plotting AP micro vs prevalence baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,15 @@ Example log line expected by the parser:
 ```
 [val 20220105] ep 01 tr:loss=0.6596 | va:APμ=0.6367 AP̄=0.3606 F1̄=0.7351 prev=0.02 sel=prauc:0.6367 (time=0.9s)
 ```
+
+## Plotting metrics
+The `scripts/plot_baseline.py` helper script generates matplotlib graphs
+showing AP micro versus its prevalence baseline and the lift over that
+baseline.  It reads metrics from the JSONL file used by the dashboard.
+
+```bash
+python scripts/plot_baseline.py
+```
+
+Set the `METRICS_PATH` environment variable if your metrics file lives at a
+non‑default location.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Flask
+matplotlib
+pandas

--- a/scripts/plot_baseline.py
+++ b/scripts/plot_baseline.py
@@ -1,0 +1,76 @@
+from typing import Tuple
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from metrics_backend import parse_metrics
+
+
+def load_summaries() -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Load metrics and return summaries split by prevalence."""
+    rows = parse_metrics(limit=0, since_day=None)
+    if not rows:
+        raise SystemExit("No metrics available. Set METRICS_PATH to your metrics.jsonl file.")
+
+    df = pd.DataFrame(rows)
+    df["lift_abs"] = df["ap_micro"] - df["prev_micro"]
+
+    # Split into high/low prevalence groups using the median prevalence as threshold
+    median_prev = df["prev_micro"].median()
+    df["group"] = df["prev_micro"].apply(lambda x: "high" if x >= median_prev else "low")
+
+    summary_high = df[df["group"] == "high"].groupby("epoch")[
+        ["ap_micro", "prev_micro", "lift_abs"]
+    ].mean()
+    summary_low = df[df["group"] == "low"].groupby("epoch")[
+        ["ap_micro", "prev_micro", "lift_abs"]
+    ].mean()
+
+    return summary_high, summary_low
+
+
+def plot(summary_high: pd.DataFrame, summary_low: pd.DataFrame) -> None:
+    """Create APμ vs prevalence and lift plots."""
+    plt.figure(figsize=(10, 5))
+    plt.plot(summary_high.index, summary_high["ap_micro"], label="High Prev - APμ", marker="o")
+    plt.plot(summary_low.index, summary_low["ap_micro"], label="Low Prev - APμ", marker="o")
+
+    plt.plot(
+        summary_high.index,
+        summary_high["prev_micro"],
+        label="High Prev Baseline",
+        linestyle="--",
+    )
+    plt.plot(
+        summary_low.index,
+        summary_low["prev_micro"],
+        label="Low Prev Baseline",
+        linestyle="--",
+    )
+
+    plt.title("AP Micro vs Prevalence Baseline")
+    plt.xlabel("Epoch")
+    plt.ylabel("Score")
+    plt.legend()
+    plt.grid(True)
+
+    plt.figure(figsize=(10, 5))
+    plt.plot(summary_high.index, summary_high["lift_abs"], label="High Prev - Lift", marker="o")
+    plt.plot(summary_low.index, summary_low["lift_abs"], label="Low Prev - Lift", marker="o")
+
+    plt.title("Lift over Baseline by Epoch")
+    plt.xlabel("Epoch")
+    plt.ylabel("Lift (APμ - prevμ)")
+    plt.axhline(0, color="black", linewidth=0.8)
+    plt.legend()
+    plt.grid(True)
+    plt.show()
+
+
+def main() -> None:
+    summary_high, summary_low = load_summaries()
+    plot(summary_high, summary_low)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/plot_baseline.py` to chart AP micro against prevalence baseline and lift
- document plotting script in README
- add matplotlib and pandas dependencies

## Testing
- `python -m py_compile scripts/plot_baseline.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adcecb70a0832792b8ce4c484933e5